### PR TITLE
fixed error with extension

### DIFF
--- a/script/Rename.ps1
+++ b/script/Rename.ps1
@@ -1,7 +1,7 @@
 if (Test-Path images\*) {
     cd images
     $files = dir
-    dir | Rename-Item -NewName {$_.Name+".tiff"}
+    dir | Rename-Item -NewName {$_.BaseName+".tiff"}
 
     Write-Host("")
     Write-Host("Renamed the following files:")


### PR DESCRIPTION
if you use "Name" it will return the full file name, "BaseName" will return just the file name otherwise it changes a file from `myImage.png` to `myImage.png.tiff`